### PR TITLE
Handle invalid expansion plate update schema version

### DIFF
--- a/src/lib/core/firmware_updater.py
+++ b/src/lib/core/firmware_updater.py
@@ -61,6 +61,7 @@ class FirmwareUpdater(object):
         success = True
 
         if self.device_info.device_name == "pt4_hub" \
+                or self.device_info.device_name == "pt4_expansion_plate" \
                 or self.device.get_fw_version_update_schema() == 0:
             requires_restart = True
             return success, requires_restart


### PR DESCRIPTION
Expansion Plate firmwares v21.10 & v21.11 state `FIRMWARE_UPDATE_SCHEMA_VERSION=1`.  Foundation Plate defines version 1 to include hot-reloading after a firmware update. All currently released Expansion Plate firmware does not implement this, therefore right now it always require a restart.